### PR TITLE
fix(api-key): fail on missing key (i.e. return non-zero)

### DIFF
--- a/src/chat-pipeline/stages/ensure-api-key.ts
+++ b/src/chat-pipeline/stages/ensure-api-key.ts
@@ -3,7 +3,7 @@ import dbg from "debug";
 import { ExecutionContext } from "../../lib/execution-context";
 import {
   ERROR_CODE_INVALID_CONFIFGURATION,
-  TerminatingWarning,
+  TerminatingError,
 } from "../../lib/errors";
 import { Configuration } from "../../configuration/configuration";
 import { init } from "../../actions/init";
@@ -22,7 +22,7 @@ export async function ensureApiKey(
   //  We don't have a key, if we're not interactive on stdin we cannot continue.
   //  Note that the error message will be in the output, so keep it short.
   if (!executionContext.isTTYstdin) {
-    throw new TerminatingWarning(
+    throw new TerminatingError(
       "error: OpenAI API Key not set",
       ERROR_CODE_INVALID_CONFIFGURATION,
     );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -202,6 +202,8 @@ async function main() {
       console.log(
         theme.printWarning(err.message, executionContext.isTTYstdout),
       );
+      //  Note: warnings do *not* fail the app, but this is likely a bad pattern.
+      process.exit(0);
     } else if (err instanceof TerminatingError) {
       console.log(theme.printError(err.message, executionContext.isTTYstdout));
       process.exit(err.errorCode);


### PR DESCRIPTION
Updated ensure-api-key.ts to replace TerminatingWarning with TerminatingError. This change improves error handling consistency when the OpenAI API Key is not set.