### PR TITLE
docs: add -g flag to npm install in quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 Install Terminal AI:
 
 ```bash
-npm install @dwmkerr/terminal-ai
+npm install -g @dwmkerr/terminal-ai
 ```
 
 Run the tool to configure your environment and start interactively interfacing with AI:


### PR DESCRIPTION
## Summary
- Adds the `-g` (global) flag to the `npm install` command in the Quickstart section so the `ai` binary is available on the user's PATH

Closes #113